### PR TITLE
fixed the link to the live demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A cross platform, cross WebView, solution to fit 100% any Web page.
 
-**[Live Demo](https://webreflection.github.com/screenfit/)**
+**[Live Demo](https://webreflection.github.io/screenfit/)**
 
 
 


### PR DESCRIPTION
GitHub Pages will stop redirecting Pages sites from *.github.com after April 15, 2021 | GitHub Changelog https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/